### PR TITLE
[Codex] Toggle notes icon to close sidebar

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -257,8 +257,9 @@ export function App() {
         <div className="topbar-left">
           <button
             className="btn icon only-mobile"
-            onClick={() => setSidebarOpen(true)}
-            aria-label="Open notes"
+            onClick={() => setSidebarOpen((value) => !value)}
+            aria-label={sidebarOpen ? 'Close notes' : 'Open notes'}
+            aria-expanded={sidebarOpen}
           >
             <NotesIcon />
           </button>


### PR DESCRIPTION
## Summary
- allow the mobile notes button to toggle the sidebar open state
- expose the sidebar state to assistive tech via aria-expanded

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cba915ef748323a83b3ab20dee1d8d