### PR TITLE
[Codex] Fix mobile editor overflow by relaxing min width

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -612,6 +612,7 @@ textarea:focus-visible {
   display: flex;
   flex-direction: column;
   min-height: 0;
+  min-width: 0;
   background: var(--bg);
 }
 


### PR DESCRIPTION
## Summary
- allow the workspace column to shrink with the viewport by relaxing its minimum width
- prevent the editor and preview panels from overflowing on Chrome for Android

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc5df1f83c83239b6bdff14f67a0af