### PR TITLE
[Codex] Refresh onboarding and home experience

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -171,19 +171,86 @@ textarea {
   gap: 24px;
 }
 
-.home-header {
+.home-shell .topbar-actions {
+  flex: 0 0 auto;
+}
+
+.home-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.3fr) minmax(0, 1fr);
+  gap: 28px;
+  background: var(--surface);
+  border: 1px solid rgba(208, 215, 222, 0.7);
+  border-radius: calc(var(--radius) + 6px);
+  box-shadow: var(--shadow-soft);
+  padding: clamp(28px, 5vw, 40px);
+  align-items: center;
+}
+
+.home-hero-text h1 {
+  margin: 0 0 12px;
+  font-size: clamp(1.9rem, 3.2vw, 2.4rem);
+}
+
+.home-hero-text p {
+  margin: 0 0 20px;
+  color: var(--muted);
+  max-width: 520px;
+}
+
+.home-hero-actions {
   display: flex;
-  flex-direction: column;
-  align-items: flex-start;
+  flex-wrap: wrap;
   gap: 12px;
 }
 
-.home-header h1 {
-  margin: 0 0 4px;
-  font-size: 1.5rem;
+.home-hero-card {
+  background: var(--surface-subtle);
+  border: 1px solid rgba(208, 215, 222, 0.7);
+  border-radius: var(--radius);
+  padding: clamp(18px, 3vw, 26px);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
-.home-header p {
+.home-hero-card h2 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.home-hero-card ul {
+  margin: 0;
+  padding-left: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  color: var(--muted);
+}
+
+.home-recents-section {
+  background: var(--surface);
+  border: 1px solid rgba(208, 215, 222, 0.7);
+  border-radius: calc(var(--radius) + 4px);
+  box-shadow: var(--shadow);
+  padding: clamp(20px, 3vw, 28px);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.home-recents-header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.home-recents-header h2 {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.home-recents-header p {
   margin: 0;
   color: var(--muted);
 }
@@ -236,24 +303,190 @@ textarea {
 }
 
 .home-empty {
-  border: 1px dashed var(--border);
-  border-radius: var(--radius);
-  padding: 32px;
+  border: 1px solid rgba(208, 215, 222, 0.7);
+  border-radius: calc(var(--radius) + 4px);
+  padding: clamp(28px, 4vw, 36px);
   text-align: center;
   color: var(--muted);
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 16px;
   align-items: center;
+  background: var(--surface);
+  box-shadow: var(--shadow);
 }
 
 .home-empty h2 {
   margin: 0;
   color: var(--text);
+  font-size: 1.4rem;
 }
 
 .home-empty p {
-  margin: 0 0 8px;
+  margin: 0;
+  max-width: 420px;
+}
+
+.onboarding-main {
+  max-width: 960px;
+  margin: 40px auto 80px;
+  padding: 0 clamp(16px, 4vw, 32px);
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.onboarding-hero {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.onboarding-hero h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 3vw, 2.2rem);
+}
+
+.onboarding-hero p {
+  margin: 0;
+  color: var(--muted);
+  max-width: 640px;
+}
+
+.onboarding-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.onboarding-card {
+  background: var(--surface);
+  border: 1px solid rgba(208, 215, 222, 0.7);
+  border-radius: calc(var(--radius) + 4px);
+  box-shadow: var(--shadow);
+  padding: clamp(22px, 4vw, 32px);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.onboarding-step {
+  align-self: flex-start;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 4px 12px;
+  border-radius: 999px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.onboarding-card h2 {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.onboarding-card p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.onboarding-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.onboarding-create {
+  background: var(--surface-subtle);
+  border: 1px solid rgba(208, 215, 222, 0.7);
+  border-radius: var(--radius);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.onboarding-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.onboarding-input-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  padding: 8px 12px;
+}
+
+.onboarding-owner-prefix {
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.onboarding-name-input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  padding: 0;
+  min-width: 0;
+  font-weight: 600;
+}
+
+.onboarding-name-input:focus-visible {
+  outline: none;
+}
+
+.onboarding-connected {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  border: 1px solid rgba(208, 215, 222, 0.7);
+  border-radius: var(--radius);
+  background: var(--surface-subtle);
+  padding: 16px;
+}
+
+.onboarding-connected-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.onboarding-connected-name {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.onboarding-connected-handle {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.onboarding-error {
+  margin: 0;
+  color: #cf222e;
+  font-weight: 500;
+}
+
+.onboarding-status {
+  margin: 0;
+  color: var(--muted);
+}
+
+.onboarding-status.success {
+  color: var(--success);
+}
+
+.onboarding-status.error {
+  color: #cf222e;
 }
 
 .toolbar {
@@ -989,6 +1222,16 @@ textarea:focus-visible {
     right: 18px;
     bottom: 18px;
   }
+
+  .onboarding-connected {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .onboarding-actions > .btn,
+  .onboarding-actions .btn.full-width {
+    width: 100%;
+  }
 }
 
 @media (max-width: 640px) {
@@ -1010,11 +1253,6 @@ textarea:focus-visible {
     padding: 0 18px;
   }
 
-  .home-header {
-    grid-template-columns: 1fr;
-    align-items: flex-start;
-  }
-
   .topbar-actions {
     gap: 8px;
     flex: 1 1 auto;
@@ -1027,6 +1265,30 @@ textarea:focus-visible {
   .topbar-actions .repo-btn {
     order: -1;
     margin-right: auto;
+  }
+
+  .home-hero {
+    grid-template-columns: 1fr;
+    gap: 24px;
+    padding: 24px;
+  }
+
+  .home-hero-card {
+    padding: 18px;
+  }
+
+  .onboarding-main {
+    margin: 24px auto 56px;
+    padding: 0 18px;
+    gap: 24px;
+  }
+
+  .onboarding-card {
+    padding: 20px;
+  }
+
+  .onboarding-grid {
+    gap: 18px;
   }
 }
 
@@ -1058,6 +1320,10 @@ textarea:focus-visible {
 
   .repo-btn {
     max-width: 60vw;
+  }
+
+  .home-hero-actions .btn {
+    width: 100%;
   }
 }
 

--- a/src/ui/HomeView.tsx
+++ b/src/ui/HomeView.tsx
@@ -25,7 +25,7 @@ export function HomeView({ recents, navigate }: HomeViewProps) {
     return entry.slug;
   };
 
-  const goCreateRepo = () => {
+  const goToSetup = () => {
     navigate({ kind: 'new' });
   };
 
@@ -35,38 +35,61 @@ export function HomeView({ recents, navigate }: HomeViewProps) {
         <div className="topbar-left">
           <span className="brand">VibeNote</span>
         </div>
-        <div className="topbar-actions" />
-      </header>
-      <main className="home-main">
-        <section className="home-header">
-          <div>
-            <h1>Recent repositories</h1>
-            <p>Jump back into your notes or connect a new GitHub repo.</p>
-          </div>
-          <button className="btn primary" onClick={goCreateRepo}>
+        <div className="topbar-actions">
+          <button className="btn secondary" onClick={goToSetup}>
             Create notes repository
           </button>
+        </div>
+      </header>
+      <main className="home-main">
+        <section className="home-hero">
+          <div className="home-hero-text">
+            <h1>Bring your notes to GitHub</h1>
+            <p>Turn a repository into a Markdown notebook with offline-first editing and quick GitHub sync.</p>
+            <div className="home-hero-actions">
+              <button className="btn primary" onClick={goToSetup}>
+                Create notes repository
+              </button>
+              <button className="btn ghost" onClick={goToSetup}>
+                Link existing repository
+              </button>
+            </div>
+          </div>
+          <div className="home-hero-card">
+            <h2>Why VibeNote?</h2>
+            <ul>
+              <li>Notes stay as Markdown files in your repo</li>
+              <li>Offline-first editing with optimistic sync</li>
+              <li>Automatic merges powered by Y.js</li>
+            </ul>
+          </div>
         </section>
         {hasRepos ? (
-          <ul className="home-recents">
-            {repos.map((entry) => (
-              <li key={entry.slug}>
-                <button className="home-repo" onClick={() => openEntry(entry)}>
-                  <span className="home-repo-label">{renderLabel(entry)}</span>
-                  <span aria-hidden className="home-repo-arrow">
-                    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor">
-                      <path d="M6 12 10 8 6 4" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
-                    </svg>
-                  </span>
-                </button>
-              </li>
-            ))}
-          </ul>
+          <section className="home-recents-section">
+            <div className="home-recents-header">
+              <h2>Recent repositories</h2>
+              <p>Pick up where you left off.</p>
+            </div>
+            <ul className="home-recents">
+              {repos.map((entry) => (
+                <li key={entry.slug}>
+                  <button className="home-repo" onClick={() => openEntry(entry)}>
+                    <span className="home-repo-label">{renderLabel(entry)}</span>
+                    <span aria-hidden className="home-repo-arrow">
+                      <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor">
+                        <path d="M6 12 10 8 6 4" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
+                      </svg>
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </section>
         ) : (
           <section className="home-empty">
             <h2>Connect your first repository</h2>
-            <p>Bring an existing GitHub notes repo into VibeNote to get started.</p>
-            <button className="btn primary" onClick={goCreateRepo}>
+            <p>Start a fresh notes repo on GitHub or link one you already use.</p>
+            <button className="btn primary" onClick={goToSetup}>
               Create notes repository
             </button>
           </section>


### PR DESCRIPTION
## Summary
- add a dedicated /new onboarding flow with create/link guidance and improved status messaging
- guard repo linking and GitHub owner detection when tokens are missing or API calls fail
- redesign the home hero and recents layout with the supporting styling updates

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc5e1c79e4832386e6860e656f2243