### PR TITLE
[Codex] Refresh onboarding and home screens for repo setup

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -171,21 +171,232 @@ textarea {
   gap: 24px;
 }
 
-.home-header {
+.home-hero {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  gap: 18px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: clamp(24px, 6vw, 36px);
+  box-shadow: var(--shadow);
+}
+
+.home-hero-text {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.home-hero-text h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+}
+
+.home-hero-text p {
+  margin: 0;
+  color: var(--muted);
+  max-width: 600px;
+}
+
+.home-hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.home-section {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.home-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   gap: 12px;
 }
 
-.home-header h1 {
-  margin: 0 0 4px;
-  font-size: 1.5rem;
+.home-section-header h2 {
+  margin: 0;
+  font-size: 1.2rem;
 }
 
-.home-header p {
+.home-section-subtitle {
   margin: 0;
   color: var(--muted);
+}
+
+.home-empty-card {
+  border: 1px dashed var(--border);
+  border-radius: var(--radius);
+  padding: clamp(28px, 6vw, 36px);
+  background: var(--surface);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  align-items: center;
+}
+
+.home-empty-card h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.home-empty-card p {
+  margin: 0;
+  color: var(--muted);
+  max-width: 520px;
+}
+
+.home-empty-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: center;
+}
+
+.onboarding-main {
+  max-width: 960px;
+  margin: 40px auto;
+  padding: 0 clamp(16px, 4vw, 32px);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.onboarding-hero {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.onboarding-hero h1 {
+  margin: 0;
+  font-size: clamp(1.9rem, 3.5vw, 2.6rem);
+}
+
+.onboarding-hero p {
+  margin: 0;
+  color: var(--muted);
+  max-width: 640px;
+}
+
+.onboarding-banner {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface-subtle);
+  padding: 12px 16px;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.onboarding-grid {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.onboarding-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: clamp(20px, 5vw, 28px);
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.onboarding-card h2 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.onboarding-card p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.onboarding-step {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.onboarding-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.onboarding-connected {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background: var(--surface-subtle);
+}
+
+.onboarding-connected-label {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.onboarding-connected-user {
+  font-weight: 600;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+
+.onboarding-connected-handle {
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.onboarding-hint {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.onboarding-secondary {
+  background: var(--surface-subtle);
+}
+
+.onboarding-list {
+  margin: 0;
+  padding-left: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  color: var(--muted);
+}
+
+.onboarding-list li {
+  margin: 0;
+}
+
+kbd {
+  display: inline-block;
+  padding: 2px 6px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--surface-subtle);
+  font-size: 0.85rem;
+  line-height: 1.2;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
+    'Courier New', monospace;
 }
 
 .home-recents {
@@ -235,26 +446,6 @@ textarea {
   display: inline-flex;
 }
 
-.home-empty {
-  border: 1px dashed var(--border);
-  border-radius: var(--radius);
-  padding: 32px;
-  text-align: center;
-  color: var(--muted);
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  align-items: center;
-}
-
-.home-empty h2 {
-  margin: 0;
-  color: var(--text);
-}
-
-.home-empty p {
-  margin: 0 0 8px;
-}
 
 .toolbar {
   display: flex;

--- a/src/ui/HomeView.tsx
+++ b/src/ui/HomeView.tsx
@@ -35,40 +35,69 @@ export function HomeView({ recents, navigate }: HomeViewProps) {
         <div className="topbar-left">
           <span className="brand">VibeNote</span>
         </div>
-        <div className="topbar-actions" />
+        <div className="topbar-actions">
+          <button className="btn secondary" onClick={goCreateRepo}>
+            New repository
+          </button>
+        </div>
       </header>
       <main className="home-main">
-        <section className="home-header">
-          <div>
-            <h1>Recent repositories</h1>
-            <p>Jump back into your notes or connect a new GitHub repo.</p>
+        <section className="home-hero">
+          <div className="home-hero-text">
+            <h1>Keep your release notes in sync</h1>
+            <p>
+              Spin up a dedicated notes repository on GitHub and share shipping context with your
+              team in minutes.
+            </p>
           </div>
-          <button className="btn primary" onClick={goCreateRepo}>
-            Create notes repository
-          </button>
-        </section>
-        {hasRepos ? (
-          <ul className="home-recents">
-            {repos.map((entry) => (
-              <li key={entry.slug}>
-                <button className="home-repo" onClick={() => openEntry(entry)}>
-                  <span className="home-repo-label">{renderLabel(entry)}</span>
-                  <span aria-hidden className="home-repo-arrow">
-                    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor">
-                      <path d="M6 12 10 8 6 4" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
-                    </svg>
-                  </span>
-                </button>
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <section className="home-empty">
-            <h2>Connect your first repository</h2>
-            <p>Bring an existing GitHub notes repo into VibeNote to get started.</p>
+          <div className="home-hero-actions">
             <button className="btn primary" onClick={goCreateRepo}>
               Create notes repository
             </button>
+            <button className="btn ghost" onClick={goCreateRepo}>
+              Link existing repo
+            </button>
+          </div>
+        </section>
+        {hasRepos ? (
+          <section className="home-section">
+            <div className="home-section-header">
+              <h2>Recent repositories</h2>
+              <button className="btn subtle" onClick={goCreateRepo}>
+                Connect another
+              </button>
+            </div>
+            <p className="home-section-subtitle">Jump back into a repo you've opened recently.</p>
+            <ul className="home-recents">
+              {repos.map((entry) => (
+                <li key={entry.slug}>
+                  <button className="home-repo" onClick={() => openEntry(entry)}>
+                    <span className="home-repo-label">{renderLabel(entry)}</span>
+                    <span aria-hidden className="home-repo-arrow">
+                      <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor">
+                        <path d="M6 12 10 8 6 4" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
+                      </svg>
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ) : (
+          <section className="home-empty-card">
+            <h2>Create your first notes repository</h2>
+            <p>
+              We'll initialize a private repo under your GitHub account with a README so teammates know
+              how to contribute.
+            </p>
+            <div className="home-empty-actions">
+              <button className="btn primary" onClick={goCreateRepo}>
+                Create notes repository
+              </button>
+              <button className="btn ghost" onClick={goCreateRepo}>
+                Link existing repo
+              </button>
+            </div>
           </section>
         )}
       </main>


### PR DESCRIPTION
## Summary
- redesign the home view with a hero, clearer “create notes repository” CTA, and refined recent repo section
- add a dedicated onboarding layout for /new with GitHub connection guidance and repo creation messaging
- expand styling to support the new onboarding cards, hero sections, and keyboard shortcut hints

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc5e1c79e4832386e6860e656f2243