### PR TITLE
[Codex] Render LaTeX math in markdown preview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
         "jose": "^5.9.3",
+        "katex": "^0.16.22",
         "marked": "^11.2.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -2040,6 +2041,15 @@
         "color-support": "bin.js"
       }
     },
+    "node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3300,6 +3310,22 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/katex": {
+      "version": "0.16.22",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.22.tgz",
+      "integrity": "sha512-XCHRdUw4lf3SKBaJe4EvgqIuWwkPSo9XoeO8GjQW94Bp7TWv9hNhzZjZ+OH9yf1UmLygb7DIT5GSFQiyt16zYg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
     },
     "node_modules/lib0": {
       "version": "0.2.114",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@types/dompurify": "^3.0.5",
     "diff-match-patch": "^1.0.5",
     "dompurify": "^3.2.7",
+    "katex": "^0.16.22",
     "marked": "^11.2.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",


### PR DESCRIPTION
## Summary
- add KaTeX-backed marked extensions to render inline and block math syntax in note previews
- import the KaTeX stylesheet so rendered formulas inherit the expected styling

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d65498463883239a0cd1210c29bce6