### PR TITLE
[Codex] Prune stale note content and hydrate lazily

### DIFF
--- a/src/sync/git-sync.ts
+++ b/src/sync/git-sync.ts
@@ -266,7 +266,7 @@ export async function syncBidirectional(store: LocalStore, slug: string): Promis
     const lastRemoteSha = doc.lastRemoteSha;
     if (e.sha === lastRemoteSha) {
       // Remote unchanged since base
-      const changedLocally = doc.lastSyncedHash !== hashText(doc.text || '');
+      const changedLocally = doc.isPruned !== true && doc.lastSyncedHash !== hashText(doc.text || '');
       if (changedLocally) {
         const newSha = await putFile(
           config,
@@ -283,7 +283,7 @@ export async function syncBidirectional(store: LocalStore, slug: string): Promis
       if (!rf) continue;
       const base = lastRemoteSha ? await fetchBlob(config, lastRemoteSha) : '';
       const localText = doc.text || '';
-      if (doc.lastSyncedHash !== hashText(localText)) {
+      if (doc.isPruned !== true && doc.lastSyncedHash !== hashText(localText)) {
         // both changed → merge
         const mergedText = mergeMarkdown(base ?? '', localText, rf.text);
         if (mergedText !== localText) {
@@ -316,7 +316,7 @@ export async function syncBidirectional(store: LocalStore, slug: string): Promis
       const local = findByPath(storeSlug, meta.path);
       if (!local) continue;
       const { id, doc } = local;
-      const changedLocally = doc.lastSyncedHash !== hashText(doc.text || '');
+      const changedLocally = doc.isPruned !== true && doc.lastSyncedHash !== hashText(doc.text || '');
       if (changedLocally) {
         // Restore to remote
         const newSha = await putFile(config, { path: doc.path, text: doc.text }, 'vibenote: restore note');


### PR DESCRIPTION
## Summary
- add pruning helpers that strip note text for synced, inactive entries and enforce age and size limits in local storage
- hydrate pruned documents on selection, update sync logic to treat them as unchanged, and trigger pruning for inactive repos
- cover pruning with a dedicated storage test

## Testing
- VITE_VIBENOTE_API_BASE=https://example.dev npx vitest run src/storage/local.test.ts
- npm run check


------
https://chatgpt.com/codex/tasks/task_e_68d654cd34f48323bfed9ee3ef007757