### PR TITLE
[Codex] Add note move control in file tree

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1178,10 +1178,43 @@ textarea:focus-visible {
   border: 1px solid var(--border);
   border-radius: 8px;
   box-shadow: var(--shadow);
-  padding: 4px;
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  z-index: 2;
+}
+
+.tree-menu-actions {
   display: flex;
   gap: 6px;
-  z-index: 2;
+  flex-wrap: wrap;
+}
+
+.tree-menu-move {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.tree-menu-label {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.tree-menu-select {
+  font-size: 12px;
+  padding: 4px 6px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+  color: inherit;
+}
+
+.tree-menu-select:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+  outline: none;
 }
 
 .account-menu {

--- a/src/ui/RepoView.tsx
+++ b/src/ui/RepoView.tsx
@@ -487,10 +487,31 @@ export function RepoView({ slug, route, navigate, onRecordRecent }: RepoViewProp
       store.renameNote(id, title);
       setNotes(store.listNotes());
       setFolders(store.listFolders());
+      setDoc((prev) => {
+        if (!prev || prev.id !== id) return prev;
+        return store.loadNote(id);
+      });
       scheduleAutoSync();
     } catch (e) {
       console.error(e);
       setSyncMsg('Invalid title. Avoid / and control characters.');
+    }
+  };
+
+  const onMove = (id: string, dir: string) => {
+    if (!canEdit) return;
+    try {
+      store.moveNoteToDir(id, dir);
+      setNotes(store.listNotes());
+      setFolders(store.listFolders());
+      setDoc((prev) => {
+        if (!prev || prev.id !== id) return prev;
+        return store.loadNote(id);
+      });
+      scheduleAutoSync();
+    } catch (e) {
+      console.error(e);
+      setSyncMsg('Unable to move note.');
     }
   };
 
@@ -1041,6 +1062,7 @@ export function RepoView({ slug, route, navigate, onRecordRecent }: RepoViewProp
                       setSidebarOpen(false);
                     }}
                     onRenameFile={canEdit ? onRename : () => undefined}
+                    onMoveFile={canEdit ? onMove : () => undefined}
                     onDeleteFile={canEdit ? onDelete : () => undefined}
                     onCreateFile={
                       canEdit


### PR DESCRIPTION
## Summary
- add a folder selector to the file tree context menu to move notes between directories
- update RepoView to move notes through LocalStore and refresh the active document state
- tweak tree menu styles to accommodate the new move controls

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d654ea29408323a2d6b1c1e2fed8c0