### PR TITLE
[Codex] Match repo shortcut modifier to platform

### DIFF
--- a/src/ui/RepoView.tsx
+++ b/src/ui/RepoView.tsx
@@ -87,15 +87,8 @@ const initialAccessState: RepoAccessState = {
 
 const AUTO_SYNC_MIN_INTERVAL_MS = 60_000;
 const AUTO_SYNC_DEBOUNCE_MS = 10_000;
-const APPLE_PLATFORM_PATTERN = /mac|iphone|ipad|ipod/i;
 
-function detectPrimaryShortcut(): 'meta' | 'ctrl' {
-  if (typeof navigator === 'undefined') return 'ctrl';
-  let platform = navigator.platform ?? '';
-  if (!platform && typeof navigator.userAgent === 'string') platform = navigator.userAgent;
-  if (APPLE_PLATFORM_PATTERN.test(platform)) return 'meta';
-  return 'ctrl';
-}
+const primaryModifier = detectPrimaryShortcut();
 
 export function RepoView(props: RepoViewProps) {
   return <RepoViewInner key={props.slug} {...props} />;
@@ -497,12 +490,13 @@ function RepoViewInner({ slug, route, navigate, onRecordRecent }: RepoViewProps)
 
   // Toggle the repo switcher overlay.
   const [showSwitcher, setShowSwitcher] = useState(false);
-  const primaryModifier = useMemo(() => detectPrimaryShortcut(), []);
-  const repoShortcutLabel = primaryModifier === 'meta' ? '⌘K' : 'Ctrl+K';
-  const repoButtonBaseTitle = route.kind === 'repo' ? (linked ? 'Change repository' : 'Choose repository') : 'Choose repository';
-  const repoButtonTitle = `${repoButtonBaseTitle} (${repoShortcutLabel})`;
 
   // Keyboard shortcuts: Cmd/Ctrl+K and "g" then "r" open the repo switcher.
+  const repoShortcutLabel = primaryModifier === 'meta' ? '⌘K' : 'Ctrl+K';
+  const repoButtonBaseTitle =
+    route.kind === 'repo' ? (linked ? 'Change repository' : 'Choose repository') : 'Choose repository';
+  const repoButtonTitle = `${repoButtonBaseTitle} (${repoShortcutLabel})`;
+
   useEffect(() => {
     let lastG = 0;
     const isTypingTarget = (el: EventTarget | null) => {
@@ -1492,4 +1486,13 @@ function foldersEqual(a: string[], b: string[]): boolean {
     if (a[i] !== b[i]) return false;
   }
   return true;
+}
+
+function detectPrimaryShortcut(): 'meta' | 'ctrl' {
+  if (typeof navigator === 'undefined') return 'ctrl';
+  let platform = navigator.platform ?? '';
+  if (!platform && typeof navigator.userAgent === 'string') platform = navigator.userAgent;
+  const APPLE_PLATFORM_PATTERN = /mac|iphone|ipad|ipod/i;
+  if (APPLE_PLATFORM_PATTERN.test(platform)) return 'meta';
+  return 'ctrl';
 }

--- a/src/ui/RepoView.tsx
+++ b/src/ui/RepoView.tsx
@@ -529,7 +529,7 @@ function RepoViewInner({ slug, route, navigate, onRecordRecent }: RepoViewProps)
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [primaryModifier]);
+  }, []);
 
   return (
     <div className="app-shell">


### PR DESCRIPTION
## Summary
- detect Apple platforms to choose the repo switcher shortcut modifier
- only trigger Cmd+K on macOS/iOS and Ctrl+K elsewhere, and surface the platform-specific hint in button tooltips

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68dfa841aaf08323bb6dc5cc740a5bc7