### PR TITLE
fix: inline math parsing — use GitHub/pandoc dollar sign rules

### DIFF
--- a/src/lib/render-markdown.ts
+++ b/src/lib/render-markdown.ts
@@ -124,8 +124,8 @@ function configureMarkedOnce() {
     },
     tokenizer(src) {
       if (src[0] !== '$' || src[1] === '$') return undefined;
-      // Don't match currency: $ followed by a digit or comma (e.g. $1,200)
-      if (src[1] !== undefined && /[\d,]/.test(src[1])) return undefined;
+      // Opening $ must not be followed by whitespace
+      if (src[1] !== undefined && /\s/.test(src[1])) return undefined;
       let index = 1;
       let closing = -1;
       while (index < src.length) {
@@ -135,6 +135,10 @@ function configureMarkedOnce() {
           continue;
         }
         if (char === '$') {
+          // Closing $ must not be preceded by whitespace
+          if (index > 1 && /\s/.test(src[index - 1])) { index += 1; continue; }
+          // Closing $ must not be followed by a digit (avoids currency like $1,200)
+          if (index + 1 < src.length && /\d/.test(src[index + 1])) { index += 1; continue; }
           closing = index;
           break;
         }

--- a/src/lib/render-markdown.ts
+++ b/src/lib/render-markdown.ts
@@ -136,9 +136,9 @@ function configureMarkedOnce() {
         }
         if (char === '$') {
           // Closing $ must not be preceded by whitespace
-          if (index > 1 && /\s/.test(src[index - 1])) { index += 1; continue; }
+          if (index > 1 && /\s/.test(src[index - 1] ?? '')) { index += 1; continue; }
           // Closing $ must not be followed by a digit (avoids currency like $1,200)
-          if (index + 1 < src.length && /\d/.test(src[index + 1])) { index += 1; continue; }
+          if (index + 1 < src.length && /\d/.test(src[index + 1] ?? '')) { index += 1; continue; }
           closing = index;
           break;
         }


### PR DESCRIPTION
Replace the opening-side currency heuristic (reject $ followed by digit) with the standard closing-side rules used by GitHub and pandoc:

1. Opening \$ must not be followed by whitespace
2. Closing \$ must not be preceded by whitespace
3. Closing \$ must not be followed by a digit

This correctly handles both currency (\$1,200) and math starting with digits (\$2^{31}\$, \$1\$) without false positives.

**Before:** `$2^{31} \equiv 1 \pmod{P}$` was rejected because the old heuristic treated any \$+digit as currency.

**After:** Parsed correctly as LaTeX math, matching GitHub's behavior.