### PR TITLE
Add sync integration harness for GitHub-backed flows

### DIFF
--- a/src/data/data.integration.test.ts
+++ b/src/data/data.integration.test.ts
@@ -1,0 +1,176 @@
+// Integration tests for the writable repo data flow using the real sync layer.
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useEffect, useState } from 'react';
+import { beforeAll, beforeEach, afterEach, describe, expect, test, vi } from 'vitest';
+import type { RepoMetadata } from '../lib/backend';
+import type { RepoRoute } from '../ui/routing';
+import { MockRemoteRepo } from '../test/mock-remote';
+
+type AuthMocks = {
+  signInWithGitHubApp: ReturnType<typeof vi.fn>;
+  getSessionToken: ReturnType<typeof vi.fn>;
+  getSessionUser: ReturnType<typeof vi.fn>;
+  ensureFreshAccessToken: ReturnType<typeof vi.fn>;
+  signOutFromGitHubApp: ReturnType<typeof vi.fn>;
+  getAccessTokenRecord: ReturnType<typeof vi.fn>;
+};
+
+type BackendMocks = {
+  getRepoMetadata: ReturnType<typeof vi.fn>;
+  getInstallUrl: ReturnType<typeof vi.fn>;
+};
+
+const authModule = vi.hoisted<AuthMocks>(() => ({
+  signInWithGitHubApp: vi.fn(),
+  getSessionToken: vi.fn(),
+  getSessionUser: vi.fn(),
+  ensureFreshAccessToken: vi.fn(),
+  signOutFromGitHubApp: vi.fn(),
+  getAccessTokenRecord: vi.fn(),
+}));
+
+const backendModule = vi.hoisted<BackendMocks>(() => ({
+  getRepoMetadata: vi.fn(),
+  getInstallUrl: vi.fn(),
+}));
+
+vi.mock('../auth/app-auth', () => ({
+  signInWithGitHubApp: authModule.signInWithGitHubApp,
+  getSessionToken: authModule.getSessionToken,
+  getSessionUser: authModule.getSessionUser,
+  ensureFreshAccessToken: authModule.ensureFreshAccessToken,
+  signOutFromGitHubApp: authModule.signOutFromGitHubApp,
+  getAccessTokenRecord: authModule.getAccessTokenRecord,
+}));
+
+vi.mock('../lib/backend', () => ({
+  getRepoMetadata: backendModule.getRepoMetadata,
+  getInstallUrl: backendModule.getInstallUrl,
+}));
+
+let useRepoData: typeof import('../data').useRepoData;
+
+beforeAll(async () => {
+  ({ useRepoData } = await import('../data'));
+});
+
+const mockGetSessionToken = authModule.getSessionToken;
+const mockGetSessionUser = authModule.getSessionUser;
+const mockEnsureFreshAccessToken = authModule.ensureFreshAccessToken;
+const mockGetAccessTokenRecord = authModule.getAccessTokenRecord;
+const mockGetRepoMetadata = backendModule.getRepoMetadata;
+const mockGetInstallUrl = backendModule.getInstallUrl;
+
+const writableMeta: RepoMetadata = {
+  isPrivate: true,
+  installed: true,
+  repoSelected: true,
+  defaultBranch: 'main',
+  manageUrl: null,
+};
+
+type RecordRecentFn = (entry: { slug: string; owner?: string; repo?: string; connected?: boolean }) => void;
+
+function renderRepoData(initial: { slug: string; route: RepoRoute; recordRecent: RecordRecentFn }) {
+  return renderHook(
+    ({ slug, route, recordRecent }: { slug: string; route: RepoRoute; recordRecent: RecordRecentFn }) => {
+      let [routeState, setRouteState] = useState<RepoRoute>(route);
+      useEffect(() => {
+        setRouteState(route);
+      }, [route]);
+      return useRepoData({
+        slug,
+        route: routeState,
+        recordRecent,
+        setActivePath: (nextPath, options) => {
+          setRouteState((prev) => {
+            if (prev.kind !== 'repo') return prev;
+            return { ...prev, notePath: nextPath };
+          });
+        },
+      });
+    },
+    { initialProps: initial }
+  );
+}
+
+describe('useRepoData integration', () => {
+  let remote: MockRemoteRepo;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    localStorage.clear();
+
+    remote = new MockRemoteRepo();
+    remote.configure('acme', 'docs');
+    remote.allowToken('access-token');
+
+    fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => remote.handleFetch(input, init));
+    vi.stubGlobal('fetch', fetchMock);
+
+    mockGetSessionToken.mockReset();
+    mockGetSessionUser.mockReset();
+    mockEnsureFreshAccessToken.mockReset();
+    mockGetAccessTokenRecord.mockReset();
+    mockGetRepoMetadata.mockReset();
+    mockGetInstallUrl.mockReset();
+
+    mockGetSessionToken.mockReturnValue('session-token');
+    mockGetSessionUser.mockReturnValue({
+      login: 'mona',
+      name: 'Mona',
+      avatarUrl: 'https://example.com/mona.png',
+    });
+    mockEnsureFreshAccessToken.mockResolvedValue('access-token');
+    mockGetAccessTokenRecord.mockReturnValue({ token: 'access-token', expiresAt: Date.now() + 60_000 });
+    mockGetRepoMetadata.mockResolvedValue({ ...writableMeta });
+    mockGetInstallUrl.mockResolvedValue('https://github.com/apps/vibenote/installations/new');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test('imports remote files, pushes local edits, and pulls remote updates through the real sync path', async () => {
+    let slug = 'acme/docs';
+    let recordRecent = vi.fn<RecordRecentFn>();
+
+    remote.setFile('README.md', '# Remote readme');
+    remote.setFile('Guide.md', 'initial guide');
+
+    let { result } = renderRepoData({
+      slug,
+      route: { kind: 'repo', owner: 'acme', repo: 'docs' },
+      recordRecent,
+    });
+
+    await waitFor(() => expect(result.current.state.repoQueryStatus).toBe('ready'));
+    await waitFor(() => expect(result.current.state.repoLinked).toBe(true));
+    await waitFor(() =>
+      expect(result.current.state.files.map((file) => file.path).sort()).toEqual(['Guide.md', 'README.md'])
+    );
+    await waitFor(() => expect(result.current.state.activeFile?.path).toBe('README.md'));
+    await waitFor(() => expect(result.current.state.activeFile?.content).toBe('# Remote readme'));
+
+    act(() => {
+      result.current.actions.saveFile('README.md', '# Local edit');
+    });
+
+    await act(async () => {
+      await result.current.actions.syncNow();
+    });
+
+    expect(remote.snapshot().get('README.md')).toBe('# Local edit');
+    expect(result.current.state.statusMessage).toContain('Synced:');
+    expect(result.current.state.statusMessage).toContain('pushed 1');
+
+    remote.setFile('README.md', '# Remote update');
+
+    await act(async () => {
+      await result.current.actions.syncNow();
+    });
+
+    await waitFor(() => expect(result.current.state.activeFile?.content).toBe('# Remote update'));
+    expect(remote.snapshot().get('README.md')).toBe('# Remote update');
+  });
+});

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -1,0 +1,16 @@
+---
+status: done
+created: 2026-03-05
+completed: 2026-03-05
+---
+
+# Task board
+
+Lightweight task tracking for agent-driven work.
+
+Conventions:
+
+- One Markdown file per task.
+- `status` is one of `todo`, `active`, `done`, `blocked`.
+- Keep tasks focused on intent, must-haves, and validation.
+- Avoid over-specifying implementation details unless a constraint is real and important.

--- a/tasks/audit-sync-flow-test-gaps.md
+++ b/tasks/audit-sync-flow-test-gaps.md
@@ -1,0 +1,67 @@
+---
+status: done
+created: 2026-03-05
+completed: 2026-03-05
+assigned: codex-manager
+---
+
+# Audit current test coverage for sync-heavy flows
+
+Identify what the repo already tests well, what is only tested in isolation, and which cross-layer flows are currently undercovered.
+
+The goal is to give the project manager a grounded view of where an end-to-end harness will pay off most. This should guide scope, not create a large design document.
+
+Must-haves:
+
+- Review the existing frontend, backend, and sync-related tests.
+- Identify a short list of high-value user flows that are currently not covered end-to-end.
+- Call out any existing helpers or mocks that should be reused instead of replaced.
+
+Success will be validated by:
+
+- A concise written summary is added to this task file.
+- The summary names the most important missing flow or flows to target first.
+- The summary is specific enough to drive the design and implementation tasks that follow.
+
+## Findings
+
+### Existing coverage is already strong in two separate layers
+
+- `src/sync/git-sync.test.ts`, `src/sync/git-sync-multi.test.ts`, `src/sync/git-sync-stale.test.ts`, and `src/sync/sync.integration.test.ts` cover the sync engine itself in depth.
+- Those tests already use `src/test/mock-remote.ts`, which behaves like a GitHub REST stub and exercises real `syncBidirectional` behavior against a remote-like API surface.
+- `src/data/data.test.ts` covers `useRepoData` behavior well at the hook level: initial loading, writable vs read-only access, manual sync actions, autosync scheduling, auth edge cases, and route/state interactions.
+- `server/src/__tests__/git-shares.test.ts` provides a real Express integration harness for share endpoints, but that coverage is mostly orthogonal to the storage/git refactor.
+
+### The main gap is the seam between the hook and the sync engine
+
+- The hook tests mock `listRepoFiles`, `pullRepoFile`, and `syncBidirectional`, so they do not verify that the real data layer wiring drives the real sync/storage stack correctly.
+- The sync tests verify the sync engine against the mock remote, but they do not mount `useRepoData` or exercise the user-facing actions that trigger sync behavior.
+- There is no single test path that starts from the real data hook actions and ends in the GitHub-like remote state while also checking the local store and user-visible state.
+
+### Highest-value missing flows
+
+- A writable repo flow that mounts `useRepoData` with the real sync module and a shared GitHub mock, then verifies remote import, local edit, and sync behavior together.
+- A follow-up variant that proves remote changes round-trip back into the active file through the same path.
+- Autosync is also a useful candidate, but it is a second step after the manual sync path is covered end-to-end.
+
+### Recommended first target
+
+- Start with one tight writable-repo flow rather than full browser e2e or full frontend+backend auth integration.
+- The best first target appears to be:
+  - visit a writable repo backed by the GitHub mock
+  - import remote files into local state through the real data-layer path
+  - edit via `useRepoData` actions
+  - call `syncNow`
+  - verify both local state and remote state
+- If scope allows, extend the same test with a simulated remote change and a second sync to verify pull behavior updates the active file.
+
+### Reuse candidates
+
+- Reuse `src/test/mock-remote.ts` as the shared GitHub mock instead of inventing a second fake API.
+- Reuse the existing `renderHook`-based `useRepoData` test style unless a stronger integration harness becomes clearly necessary.
+- Reuse the current backend metadata mocks for the first iteration; the storage/git refactor does not require full auth-server integration as the first milestone.
+
+### Current validation status
+
+- I could not execute the current test suites in this checkout because `npm test` fails with `sh: 1: vitest: not found`, which indicates dependencies are not installed locally here.
+- The audit conclusions above are based on reading the existing tests and helpers rather than running them in this environment.

--- a/tasks/design-shared-github-mock.md
+++ b/tasks/design-shared-github-mock.md
@@ -1,0 +1,55 @@
+---
+status: done
+created: 2026-03-05
+completed: 2026-03-05
+assigned: codex-manager
+---
+
+# Design a shared GitHub mock for end-to-end sync tests
+
+Define the shape of a polished GitHub mock that can support meaningful end-to-end tests spanning the relevant frontend and backend layers.
+
+The point is to decide what the harness should simulate and how it should fit into this repo, without overcommitting to unnecessary infrastructure.
+
+Must-haves:
+
+- Propose a testable target flow or flows for the first iteration.
+- Explain how the mock will be shared or reused across the layers that need it.
+- Respect the existing testing setup and reuse current helpers where sensible.
+
+Success will be validated by:
+
+- A concise design note is added to this task file.
+- The note gives enough direction that an implementation agent can proceed without guessing the product goal.
+- The proposed scope stays tight enough to land before the larger refactor work begins.
+
+## Audit input
+
+- The repo already has strong sync-engine coverage and strong hook-level coverage, but the two are tested mostly in isolation.
+- The first design milestone should therefore focus on the seam between `useRepoData` and the real sync/storage implementation.
+
+## Proposed first-iteration target
+
+Design the harness around one meaningful writable-repo flow:
+
+- mount `useRepoData` for a writable repo
+- back the repo with the existing GitHub mock in `src/test/mock-remote.ts`
+- let the real data-layer code import remote files into local state
+- edit through hook actions
+- run a real sync
+- verify user-visible state, local persistence, and remote state together
+
+This should stay intentionally narrower than:
+
+- full browser automation
+- full frontend+backend auth integration
+- a generalized test platform for every future flow
+
+Those may become follow-up tasks, but they are not necessary to de-risk the storage/git refactor.
+
+## Design constraints
+
+- Prefer reusing `MockRemoteRepo` over creating a second mock stack.
+- Prefer fitting into the current Vitest-based workflow.
+- Keep the design maintainable by future agents; avoid introducing infrastructure whose value is only hypothetical.
+- Leave room to extend the same harness later for autosync or auth-related paths if the first milestone succeeds.

--- a/tasks/e2e-github-mock-loop.md
+++ b/tasks/e2e-github-mock-loop.md
@@ -1,0 +1,37 @@
+---
+status: done
+created: 2026-03-05
+completed: 2026-03-05
+assigned: codex-manager
+---
+
+# Close the e2e testing loop for sync-heavy flows
+
+This is the umbrella task for the high-value part of issue `#67`: establish a reliable end-to-end testing loop for the app paths that depend on GitHub-backed sync behavior.
+
+The intent is not to perfect every testing workflow. The intent is to make storage/git refactors safer by giving us fast, credible coverage for the flows most likely to break across frontend, backend, auth, storage, and sync boundaries.
+
+Must-haves:
+
+- We can exercise meaningful sync-heavy app behavior end-to-end without depending on live GitHub.
+- The solution is good enough to support upcoming refactors in the data, storage, and git layers.
+- The resulting workflow is understandable and maintainable by future agents and humans.
+
+Success will be validated by:
+
+- A concrete test path exists and runs in the repo.
+- The path covers at least one real multi-layer flow that would catch regressions unit tests are likely to miss.
+- The implementation is documented well enough that a follow-up refactor can rely on it.
+
+Planned child tasks:
+
+- `audit-sync-flow-test-gaps`
+- `design-shared-github-mock`
+- `implement-sync-e2e-harness`
+- `validate-sync-e2e-harness`
+
+## Outcome
+
+The first high-value slice is complete: the repo now has a writable-repo integration test that connects the real data hook to the real sync layer through the shared GitHub mock.
+
+That is enough to de-risk the next storage/git refactor step without expanding this work into a larger browser or auth-integration project.

--- a/tasks/implement-sync-e2e-harness.md
+++ b/tasks/implement-sync-e2e-harness.md
@@ -1,0 +1,52 @@
+---
+status: done
+created: 2026-03-05
+completed: 2026-03-05
+assigned: codex-manager
+---
+
+# Implement the first end-to-end sync test harness
+
+Build the first working version of the test path defined by the audit and design tasks.
+
+The intent is to produce a practical harness, not a grand framework. It should cover the first high-value scenario well enough to start protecting the upcoming refactor.
+
+Must-haves:
+
+- Add runnable tests or supporting code in the repo that exercise the chosen multi-layer flow.
+- Use a shared GitHub mock strategy consistent with the design task.
+- Keep the solution maintainable and scoped to the agreed first milestone.
+
+Success will be validated by:
+
+- The new test path runs in the normal project test workflow, or there is a clearly justified reason if a separate invocation is required.
+- The covered flow would fail if the relevant storage/git/sync behavior regressed.
+- The task file records what was implemented and any limitations that remain.
+
+## Implemented
+
+- Added [src/data/data.integration.test.ts](/mnt/data-2tb/zks/vibenote/src/data/data.integration.test.ts), a writable-repo integration test for `useRepoData`.
+- The test keeps auth and repo-metadata boundaries mocked, but uses:
+  - the real `useRepoData` hook
+  - the real sync implementation
+  - the existing shared GitHub mock in `src/test/mock-remote.ts`
+- The covered flow is:
+  - remote repo starts with files
+  - `useRepoData` imports them into local state
+  - a local edit is made through hook actions
+  - `syncNow` pushes the edit to the remote
+  - a later remote change is pulled back into the active file through the same path
+
+## Why this is the right first milestone
+
+- It closes the highest-value gap found in the audit: the seam between the hook and the real sync/storage layer.
+- It reuses the existing mock remote instead of introducing new infrastructure.
+- It fits the current Vitest workflow cleanly and stays small enough to land before the larger refactor.
+
+## Limitations
+
+- This first harness does not cover autosync timers yet.
+- It does not cover browser-level flows.
+- It does not cover a full frontend+backend auth round-trip.
+
+Those remain valid follow-up work, but they are not required for the storage/git refactor to start with a credible safety net.

--- a/tasks/validate-sync-e2e-harness.md
+++ b/tasks/validate-sync-e2e-harness.md
@@ -1,0 +1,52 @@
+---
+status: done
+created: 2026-03-05
+completed: 2026-03-05
+blocked-by: implement-sync-e2e-harness
+assigned: codex-manager
+---
+
+# Validate the end-to-end sync harness against real app needs
+
+Review the finished harness critically and verify that it actually protects the refactor work it was meant to de-risk.
+
+This is not just "tests are green". The task is to check whether the new coverage is meaningful, stable, and aligned with the intended storage/git refactor.
+
+Must-haves:
+
+- Run the relevant checks.
+- Review whether the chosen flow truly crosses the important boundaries.
+- Identify any obvious blind spots that should be captured as follow-up tasks rather than silently ignored.
+
+Success will be validated by:
+
+- This task file contains a short validation note with findings.
+- The harness is either accepted as sufficient for the next refactor step or rejected with concrete reasons.
+- Any follow-up work is described clearly enough to spin out into separate tasks if needed.
+
+## Validation note
+
+- The new harness passes with `npm test -- src/data/data.integration.test.ts`.
+- The adjacent sync suites still pass:
+  - `npm test -- src/sync/sync.integration.test.ts src/sync/git-sync.test.ts src/sync/git-sync-multi.test.ts src/sync/git-sync-stale.test.ts`
+- The repo still type-checks with `npm run check`.
+
+## Findings
+
+- The harness crosses the important boundary that was previously missing: `useRepoData` now drives the real sync layer against the shared GitHub mock.
+- The covered flow is meaningful for the upcoming storage/git refactor because it exercises:
+  - remote import into local state
+  - local edit persistence
+  - real manual sync
+  - remote-to-local pull behavior that updates the active file
+
+## Acceptance
+
+- Accepted as sufficient for the next refactor step.
+- This is not the final word on end-to-end coverage, but it is a credible first safety net for the storage/git work.
+
+## Follow-up blind spots
+
+- Autosync behavior through the same real harness.
+- Full auth/backend integration if that area becomes volatile.
+- Browser-level regression coverage for the user-facing sync workflow.


### PR DESCRIPTION
Partial progress on #67

## Summary

- add a writable-repo integration test that connects `useRepoData` to the real sync layer via the shared GitHub mock
- create an in-repo task board for the sync-harness workstream
- document the audit, design, implementation, and validation for this slice

## Notes

- this covers one high-value part of #67 rather than the whole issue
- the test path avoids live GitHub and focuses on the multi-layer sync seam